### PR TITLE
카테고리 id별 메뉴 조회

### DIFF
--- a/src/main/java/com/NOK_NOK/order/controller/MenuController.java
+++ b/src/main/java/com/NOK_NOK/order/controller/MenuController.java
@@ -17,96 +17,40 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @Tag(name = "Menu", description = "메뉴 관리 API")
 public class MenuController {
-    
+
     private final MenuService menuService;
-    
+
     /**
-     * 전체 카테고리 목록 조회
-     * GET /api/categories
-     */
-    // @Operation(summary = "카테고리 목록 조회", description = "전체 카테고리 목록을 display_order 순으로 조회합니다.")
-    // @GetMapping("/categories")
-    // public ResponseEntity<MenuResponseDto.CategoryList> getAllCategories() {
-    //     log.info("GET /api/categories - Fetch all categories");
-        
-    //     MenuResponseDto.CategoryList response = menuService.getAllCategories();
-        
-    //     return ResponseEntity.ok(response);
-    // }
-    
-    /**
-     * 메뉴 검색 (조건 + 페이지네이션)
-     * GET /api/menus
+     * 키오스크용: 전체 카테고리와 메뉴 조회
+     * GET /api/kiosk/categories-with-menus
      * 
-     * @param categoryId 카테고리 ID (선택)
-     * @param keyword 검색 키워드 (선택)
-     * @param isActive 활성화 여부 (선택)
-     * @param page 페이지 번호 (기본값: 0)
-     * @param size 페이지 크기 (기본값: 20)
-     * @param sortBy 정렬 기준 (기본값: menuId)
-     * @param sortDirection 정렬 방향 (기본값: ASC)
+     * 각 카테고리를 하나의 "페이지"로 간주하여 반환
+     * 활성화된 메뉴만 조회
      */
-    @Operation(
-        summary = "메뉴 검색", 
-        description = "조건에 맞는 메뉴를 검색합니다. 페이지네이션을 지원합니다."
-    )
-    @GetMapping("/menus")
-    public ResponseEntity<MenuResponseDto.MenuPage> searchMenus(
-        @Parameter(description = "카테고리 ID (1: 커피, 2: 논커피, 3: 디저트)", example = "1")
-        @RequestParam(name = "categoryId", required = false) Long categoryId,
-        
-        @Parameter(description = "메뉴명 검색 키워드", example = "아메리카노")
-        @RequestParam(name = "keyword", required = false) String keyword,
-        
-        @Parameter(description = "활성화 여부 (true: 판매중, false: 판매중단)", example = "true")
-        @RequestParam(name = "isActive", required = false) Boolean isActive,
-        
-        @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
-        @RequestParam(name = "page", defaultValue = "0") Integer page,
-        
-        @Parameter(description = "페이지 크기", example = "20")
-        @RequestParam(name = "size", defaultValue = "20") Integer size,
-        
-        @Parameter(description = "정렬 기준 필드 (menuId, name, price, categoryId)", example = "menuId")
-        @RequestParam(name = "sortBy", defaultValue = "menuId") String sortBy,
-        
-        @Parameter(description = "정렬 방향 (ASC: 오름차순, DESC: 내림차순)", example = "ASC")
-        @RequestParam(name = "sortDirection", defaultValue = "ASC") String sortDirection
-    ) {
-        log.info("GET /api/menus - categoryId: {}, keyword: {}, isActive: {}, page: {}, size: {}", 
-                 categoryId, keyword, isActive, page, size);
-        
-        MenuRequestDto.Search request = MenuRequestDto.Search.builder()
-            .categoryId(categoryId)
-            .keyword(keyword)
-            .isActive(isActive)
-            .page(page)
-            .size(size)
-            .sortBy(sortBy)
-            .sortDirection(sortDirection)
-            .build();
-        
-        MenuResponseDto.MenuPage response = menuService.searchMenus(request);
-        
+    @Operation(summary = "키오스크 메뉴판 조회", description = "전체 카테고리와 각 카테고리별 활성화된 메뉴를 조회합니다. 키오스크 메인 화면용입니다.")
+    @GetMapping("/categories-with-menus")
+    public ResponseEntity<MenuResponseDto.CategoriesWithMenus> getCategoriesWithMenus() {
+        log.info("GET /api/categories-with-menus - Fetch all categories with menus for kiosk");
+
+        MenuResponseDto.CategoriesWithMenus response = menuService.getCategoriesWithMenusForKiosk();
+
         return ResponseEntity.ok(response);
     }
-    
-    // /**
-    //  * 특정 메뉴 상세 조회
-    //  * GET /api/menus/{menuId}
-    //  * 
-    //  * @param menuId 메뉴 ID
-    //  */
-    // @Operation(summary = "메뉴 상세 조회", description = "특정 메뉴의 상세 정보를 조회합니다.")
-    // @GetMapping("/menus/{menuId}")
-    // public ResponseEntity<MenuResponseDto.MenuDetail> getMenuById(
-    //     @Parameter(description = "메뉴 ID", example = "1", required = true)
-    //     @PathVariable(name = "menuId") Long menuId
-    // ) {
-    //     log.info("GET /api/menus/{} - Fetch menu detail", menuId);
-        
-    //     MenuResponseDto.MenuDetail response = menuService.getMenuById(menuId);
-        
-    //     return ResponseEntity.ok(response);
-    // }
+
+    /**
+     * 키오스크용: 특정 카테고리의 메뉴 조회
+     * GET /api/kiosk/categories/{categoryId}/menus
+     * 
+     * @param categoryId 카테고리 ID
+     */
+    @Operation(summary = "카테고리별 메뉴 조회", description = "특정 카테고리의 활성화된 메뉴만 조회합니다.")
+    @GetMapping("/menus/{categoryId}")
+    public ResponseEntity<MenuResponseDto.CategoryWithMenus> getMenusByCategory(
+            @Parameter(description = "카테고리 ID", example = "1", required = true) @PathVariable(name = "categoryId") Long categoryId) {
+        log.info("GET /api/menus/{} - Fetch menus for category", categoryId);
+
+        MenuResponseDto.CategoryWithMenus response = menuService.getMenusByCategory(categoryId);
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/NOK_NOK/order/controller/OptionController.java
+++ b/src/main/java/com/NOK_NOK/order/controller/OptionController.java
@@ -36,10 +36,10 @@ public class OptionController {
      * 
      * 응답:
      * {
-     *   "menuId": 1,
-     *   "menuName": "아메리카노",
-     *   "basePrice": 4000,
-     *   "optionGroups": [...]
+     * "menuId": 1,
+     * "menuName": "아메리카노",
+     * "basePrice": 4000,
+     * "optionGroups": [...]
      * }
      * 
      * @param menuId 메뉴 ID

--- a/src/main/java/com/NOK_NOK/order/domain/dto/MenuResponseDto.java
+++ b/src/main/java/com/NOK_NOK/order/domain/dto/MenuResponseDto.java
@@ -3,10 +3,6 @@ package com.NOK_NOK.order.domain.dto;
 import lombok.*;
 import java.util.List;
 
-@Getter
-// @NoArgsConstructor
-// @AllArgsConstructor
-@Builder
 public class MenuResponseDto {
 
     /**
@@ -40,7 +36,7 @@ public class MenuResponseDto {
     }
 
     /**
-     * 페이지네이션 메뉴 목록
+     * 페이지네이션 메뉴 목록 (기존 방식)
      */
     @Getter
     @NoArgsConstructor
@@ -65,5 +61,34 @@ public class MenuResponseDto {
     @Builder
     public static class CategoryList {
         private List<CategoryInfo> categories;
+    }
+
+    /**
+     * 카테고리별 메뉴 그룹 (키오스크 화면용)
+     * 각 카테고리를 하나의 "페이지"로 간주
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CategoryWithMenus {
+        private Long categoryId;
+        private String categoryName;
+        private Integer displayOrder;
+        private List<MenuDetail> menus;
+        private Integer menuCount; // 해당 카테고리의 메뉴 개수
+    }
+
+    /**
+     * 전체 카테고리별 메뉴 목록 (키오스크 메인 화면용)
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CategoriesWithMenus {
+        private List<CategoryWithMenus> categories;
+        private Integer totalCategories; // 전체 카테고리 수 (= 페이지 수)
+        private Integer maxMenusPerCategory; // 카테고리당 최대 메뉴 수
     }
 }

--- a/src/main/java/com/NOK_NOK/order/domain/dto/OptionResponseDto.java
+++ b/src/main/java/com/NOK_NOK/order/domain/dto/OptionResponseDto.java
@@ -44,10 +44,9 @@ public class OptionResponseDto {
                     .menuName(menuItem.getName())
                     .basePrice(menuItem.getPrice())
                     .optionGroups(
-                        menuItem.getOptionGroups().stream()
-                                .map(OptionGroupDto::from)
-                                .collect(Collectors.toList())
-                    )
+                            menuItem.getOptionGroups().stream()
+                                    .map(OptionGroupDto::from)
+                                    .collect(Collectors.toList()))
                     .build();
         }
     }
@@ -74,10 +73,9 @@ public class OptionResponseDto {
                     .isRequired(optionGroup.getIsRequired())
                     .selectionType(optionGroup.getSelectionType())
                     .options(
-                        optionGroup.getOptions().stream()
-                                .map(OptionItemDto::from)
-                                .collect(Collectors.toList())
-                    )
+                            optionGroup.getOptions().stream()
+                                    .map(OptionItemDto::from)
+                                    .collect(Collectors.toList()))
                     .build();
         }
     }

--- a/src/main/java/com/NOK_NOK/order/repository/MenuItemRepository.java
+++ b/src/main/java/com/NOK_NOK/order/repository/MenuItemRepository.java
@@ -3,11 +3,13 @@ package com.NOK_NOK.order.repository;
 import com.NOK_NOK.order.domain.entity.MenuItemEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -16,36 +18,42 @@ import java.util.Optional;
 @Repository
 public interface MenuItemRepository extends JpaRepository<MenuItemEntity, Long> {
 
-    /**
-     * 카테고리별 메뉴 조회 (페이지네이션)
-     */
-    Page<MenuItemEntity> findByCategoryId(Long categoryId, Pageable pageable);
+        /**
+         * 카테고리별 메뉴 조회 (페이지네이션)
+         */
+        Page<MenuItemEntity> findByCategoryId(Long categoryId, Pageable pageable);
 
-    /**
-     * 카테고리 + 활성화 상태별 메뉴 조회
-     */
-    Page<MenuItemEntity> findByCategoryIdAndIsActive(Long categoryId, Boolean isActive, Pageable pageable);
+        /**
+         * 카테고리 + 활성화 상태별 메뉴 조회 (페이지네이션)
+         */
+        Page<MenuItemEntity> findByCategoryIdAndIsActive(Long categoryId, Boolean isActive, Pageable pageable);
 
-    /**
-     * 키워드 검색 (메뉴명)
-     */
-    @Query("SELECT m FROM MenuItemEntity m WHERE " +
-            "(:categoryId IS NULL OR m.categoryId = :categoryId) AND " +
-            "(:isActive IS NULL OR m.isActive = :isActive) AND " +
-            "(:keyword IS NULL OR m.name LIKE %:keyword%)")
-    Page<MenuItemEntity> searchMenus(
-            @Param("categoryId") Long categoryId,
-            @Param("isActive") Boolean isActive,
-            @Param("keyword") String keyword,
-            Pageable pageable);
-            
-    /* 메뉴와 옵션 그룹을 함께 조회
-     * 
-     * DISTINCT 추가로 MultipleBagFetchException 해결
-     * 옵션 아이템은 LAZY 로딩으로 자동 조회됨
-     */
-    @Query("SELECT DISTINCT m FROM MenuItemEntity m " +
-            "LEFT JOIN FETCH m.optionGroups " +
-            "WHERE m.menuId = :menuId")
-    Optional<MenuItemEntity> findByIdWithOptions(@Param("menuId") Long menuId);
+        /**
+         * 카테고리 + 활성화 상태별 메뉴 조회 (정렬만 적용, 키오스크용)
+         */
+        List<MenuItemEntity> findByCategoryIdAndIsActive(Long categoryId, Boolean isActive, Sort sort);
+
+        /**
+         * 키워드 검색 (메뉴명)
+         */
+        @Query("SELECT m FROM MenuItemEntity m WHERE " +
+                        "(:categoryId IS NULL OR m.categoryId = :categoryId) AND " +
+                        "(:isActive IS NULL OR m.isActive = :isActive) AND " +
+                        "(:keyword IS NULL OR m.name LIKE %:keyword%)")
+        Page<MenuItemEntity> searchMenus(
+                        @Param("categoryId") Long categoryId,
+                        @Param("isActive") Boolean isActive,
+                        @Param("keyword") String keyword,
+                        Pageable pageable);
+
+        /**
+         * 메뉴와 옵션 그룹을 함께 조회
+         * 
+         * DISTINCT 추가로 MultipleBagFetchException 해결
+         * 옵션 아이템은 LAZY 로딩으로 자동 조회됨
+         */
+        @Query("SELECT DISTINCT m FROM MenuItemEntity m " +
+                        "LEFT JOIN FETCH m.optionGroups " +
+                        "WHERE m.menuId = :menuId")
+        Optional<MenuItemEntity> findByIdWithOptions(@Param("menuId") Long menuId);
 }

--- a/src/main/java/com/NOK_NOK/order/repository/OptionItemRepository.java
+++ b/src/main/java/com/NOK_NOK/order/repository/OptionItemRepository.java
@@ -41,7 +41,7 @@ public interface OptionItemRepository extends JpaRepository<OptionItemEntity, Lo
      * 추천 메뉴 기능에서 사용 예정
      * 
      * @param menuId 메뉴 ID
-     * @param limit 조회 개수
+     * @param limit  조회 개수
      * @return 인기 옵션 목록
      */
     // TODO: 나중에 구현

--- a/src/main/java/com/NOK_NOK/order/service/OptionService.java
+++ b/src/main/java/com/NOK_NOK/order/service/OptionService.java
@@ -46,7 +46,7 @@ public class OptionService {
             throw new MenuNotActiveException(menuId);
         }
 
-        log.info("[옵션 조회] 완료 - menuId: {}, 옵션 그룹 수: {}", 
+        log.info("[옵션 조회] 완료 - menuId: {}, 옵션 그룹 수: {}",
                 menuId, menuItem.getOptionGroups().size());
 
         // Entity → DTO 변환


### PR DESCRIPTION
- [x] 카테고리/메뉴 완료시 병합테스트
카테고리/메뉴 완료
옵션 조회 API 구현 완료
병합 충돌 해결 완료

API: GET /api/menus/{categoryId}
API: GET /api/menus/{menuId}/options

구현 내용:
카테고리별 메뉴 제공
테스트: Swagger UI 완료 ✅

Entity 연관관계: MenuItemEntity → OptionGroupEntity → OptionItemEntity
MultipleBagFetchException 해결 (DISTINCT)
가격 계산은 프론트엔드에서 하고 추후 결재기능구현시 검증만 진행
테스트: Swagger UI 완료 ✅

참고: Category FK는 추후 추가 예정