### PR TITLE
Feat 4.1.2 recommend menu api

### DIFF
--- a/src/main/java/com/NOK_NOK/order/controller/MenuController.java
+++ b/src/main/java/com/NOK_NOK/order/controller/MenuController.java
@@ -1,6 +1,5 @@
 package com.NOK_NOK.order.controller;
 
-import com.NOK_NOK.order.domain.dto.MenuRequestDto;
 import com.NOK_NOK.order.domain.dto.MenuResponseDto;
 import com.NOK_NOK.order.service.MenuService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/NOK_NOK/order/controller/RecommendController.java
+++ b/src/main/java/com/NOK_NOK/order/controller/RecommendController.java
@@ -1,0 +1,78 @@
+package com.NOK_NOK.order.controller;
+
+import com.NOK_NOK.order.domain.dto.RecommendRequestDto;
+import com.NOK_NOK.order.domain.dto.RecommendResponseDto;
+import com.NOK_NOK.order.service.RecommendService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 추천 메뉴 컨트롤러
+ * 
+ * API: GET /api/menus/recommend
+ * 
+ * 3단계 추천 로직:
+ * 1. 시간대 + 성별 + 연령대 (대상 인식 성공)
+ * 2. 시간대만 (디폴트 - 대상 인식 실패)
+ * 3. 전체 인기 메뉴 (최후의 대안)
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/menus")
+@RequiredArgsConstructor
+@Tag(name = "Recommend", description = "추천 메뉴 API")
+public class RecommendController {
+
+    private final RecommendService recommendService;
+
+    /**
+     * 추천 메뉴 조회
+     * 
+     * 시간대, 성별, 연령대 기반 추천 메뉴 제공
+     * 
+     * 대상 인식 성공:
+     * GET /api/menus/recommend?timeSlot=MORNING&gender=MALE&ageGroup=20대
+     * 
+     * 대상 인식 실패 (디폴트):
+     * GET /api/menus/recommend?timeSlot=MORNING
+     * 
+     * @param timeSlot 시간대 (필수)
+     * @param gender   성별 (선택)
+     * @param ageGroup 연령대 (선택)
+     * @param limit    조회 개수 (기본값: 5)
+     * @return 추천 메뉴 목록
+     */
+    @Operation(summary = "추천 메뉴 조회", description = "시간대, 성별, 연령대 기반 추천 메뉴를 제공합니다. " +
+            "대상 인식 실패 시 시간대만으로 추천합니다.")
+    @GetMapping("/recommend")
+    public ResponseEntity<RecommendResponseDto.RecommendList> getRecommendedMenus(
+            @Parameter(description = "시간대 (MORNING, AFTERNOON, EVENING)", example = "MORNING", required = true) @RequestParam(name = "timeSlot") String timeSlot,
+
+            @Parameter(description = "성별 (MALE, FEMALE) - 대상 인식 성공 시", example = "MALE") @RequestParam(name = "gender", required = false) String gender,
+
+            @Parameter(description = "연령대 (10대, 20대, 30대, 40대, 50대+) - 대상 인식 성공 시", example = "20대") @RequestParam(name = "ageGroup", required = false) String ageGroup,
+
+            @Parameter(description = "조회 개수", example = "10") @RequestParam(name = "limit", defaultValue = "10") Integer limit) {
+
+        log.info("[API] GET /api/menus/recommend - timeSlot: {}, gender: {}, ageGroup: {}, limit: {}",
+                timeSlot, gender, ageGroup, limit);
+
+        // Request DTO 생성
+        RecommendRequestDto.Recommend request = RecommendRequestDto.Recommend.builder()
+                .timeSlot(timeSlot)
+                .gender(gender)
+                .ageGroup(ageGroup)
+                .limit(limit)
+                .build();
+
+        // 추천 메뉴 조회
+        RecommendResponseDto.RecommendList response = recommendService.getRecommendedMenus(request);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/NOK_NOK/order/domain/dto/RecommendRequestDto.java
+++ b/src/main/java/com/NOK_NOK/order/domain/dto/RecommendRequestDto.java
@@ -1,0 +1,61 @@
+package com.NOK_NOK.order.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 추천 메뉴 요청 DTO
+ */
+public class RecommendRequestDto {
+
+    /**
+     * 추천 메뉴 조회 요청
+     * 
+     * API: GET /api/menus/recommend
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Recommend {
+
+        /**
+         * 시간대 (필수)
+         * MORNING: 아침 (06:00~11:59)
+         * AFTERNOON: 오후 (12:00~17:59)
+         * EVENING: 저녁 (18:00~05:59)
+         */
+        private String timeSlot;
+
+        /**
+         * 성별 (선택)
+         * MALE: 남성
+         * FEMALE: 여성
+         * null: 대상 인식 실패
+         */
+        private String gender;
+
+        /**
+         * 연령대 (선택)
+         * 10대, 20대, 30대, 40대, 50대+
+         * null: 대상 인식 실패
+         */
+        private String ageGroup;
+
+        /**
+         * 조회 개수
+         * 기본값: 5
+         */
+        @Builder.Default
+        private Integer limit = 5;
+
+        /**
+         * 대상 인식 성공 여부 확인
+         */
+        public boolean hasFullRecognition() {
+            return gender != null && ageGroup != null;
+        }
+    }
+}

--- a/src/main/java/com/NOK_NOK/order/domain/dto/RecommendResponseDto.java
+++ b/src/main/java/com/NOK_NOK/order/domain/dto/RecommendResponseDto.java
@@ -1,0 +1,107 @@
+package com.NOK_NOK.order.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 추천 메뉴 응답 DTO
+ */
+public class RecommendResponseDto {
+
+    /**
+     * 추천 메뉴 목록 응답
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RecommendList {
+
+        /**
+         * 시간대
+         */
+        private String timeSlot;
+
+        /**
+         * 성별 (대상 인식 성공 시)
+         */
+        private String gender;
+
+        /**
+         * 연령대 (대상 인식 성공 시)
+         */
+        private String ageGroup;
+
+        /**
+         * 추천 메뉴 목록
+         */
+        private List<RecommendedMenu> recommendedMenus;
+
+        /**
+         * 총 메뉴 개수
+         */
+        private Integer totalCount;
+
+        /**
+         * 추천 타입
+         * FULL: 시간대 + 성별 + 연령대 (1순위)
+         * TIME_ONLY: 시간대만 (2순위 디폴트)
+         * POPULAR: 전체 인기 (3순위)
+         */
+        private String recommendType;
+    }
+
+    /**
+     * 추천 메뉴 정보
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RecommendedMenu {
+
+        /**
+         * 메뉴 ID
+         */
+        private Long menuId;
+
+        /**
+         * 메뉴명
+         */
+        private String menuName;
+
+        /**
+         * 카테고리명
+         */
+        private String categoryName;
+
+        /**
+         * 기본 가격
+         */
+        private Integer basePrice;
+
+        /**
+         * 이미지 URL
+         */
+        private String imageUrl;
+
+        /**
+         * 주문 횟수
+         */
+        private Long orderCount;
+
+        /**
+         * 인기 순위
+         */
+        private Integer popularRank;
+
+        /**
+         * 추천 이유
+         */
+        private String recommendReason;
+    }
+}

--- a/src/main/java/com/NOK_NOK/order/domain/entity/CustomerSessionEntity.java
+++ b/src/main/java/com/NOK_NOK/order/domain/entity/CustomerSessionEntity.java
@@ -1,0 +1,62 @@
+package com.NOK_NOK.order.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * 고객 세션 Entity
+ * 
+ * 테이블: customer_session
+ * 
+ * 대상 인식 정보:
+ * - timeSlot: 시간대 (필수)
+ * - gender: 성별 (선택 - 대상 인식 성공 시)
+ * - ageGroup: 연령대 (선택 - 대상 인식 성공 시)
+ */
+@Entity
+@Table(name = "customer_session")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CustomerSessionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "session_id")
+    private Long sessionId;
+
+    /**
+     * 시간대 (필수)
+     * MORNING: 아침 (06:00~11:59)
+     * AFTERNOON: 오후 (12:00~17:59)
+     * EVENING: 저녁 (18:00~05:59)
+     */
+    @Column(name = "time_slot", length = 20)
+    private String timeSlot;
+
+    /**
+     * 성별 (선택)
+     * MALE: 남성
+     * FEMALE: 여성
+     * NULL: 대상 인식 실패
+     */
+    @Column(name = "gender", length = 10)
+    private String gender;
+
+    /**
+     * 연령대 (선택)
+     * 예: "10대", "20대", "30대", "40대", "50대+"
+     * NULL: 대상 인식 실패
+     */
+    @Column(name = "age_group", length = 10)
+    private String ageGroup;
+
+    /**
+     * 세션 생성 시간
+     */
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/NOK_NOK/order/domain/entity/OrderEntity.java
+++ b/src/main/java/com/NOK_NOK/order/domain/entity/OrderEntity.java
@@ -1,0 +1,60 @@
+package com.NOK_NOK.order.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 주문 Entity
+ * 
+ * 테이블: orders
+ */
+@Entity
+@Table(name = "orders")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class OrderEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
+    private Long orderId;
+
+    /**
+     * 고객 세션 (대상 인식 정보 포함)
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id")
+    private CustomerSessionEntity session;
+
+    /**
+     * 주문 시간
+     */
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    /**
+     * 총 금액
+     */
+    @Column(name = "total_amount")
+    private Integer totalAmount;
+
+    /**
+     * 주문 상태
+     * 예: PENDING, COMPLETED, CANCELLED
+     */
+    @Column(name = "status", length = 20)
+    private String status;
+
+    /**
+     * 주문 아이템 목록
+     */
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<OrderItemEntity> orderItems = new ArrayList<>();
+}

--- a/src/main/java/com/NOK_NOK/order/domain/entity/OrderItemEntity.java
+++ b/src/main/java/com/NOK_NOK/order/domain/entity/OrderItemEntity.java
@@ -1,0 +1,51 @@
+package com.NOK_NOK.order.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 주문 아이템 Entity
+ * 
+ * 테이블: order_item
+ * 
+ * 주문에 포함된 메뉴 정보
+ */
+@Entity
+@Table(name = "order_item")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class OrderItemEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_item_id")
+    private Long orderItemId;
+
+    /**
+     * 주문
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private OrderEntity order;
+
+    /**
+     * 메뉴
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id")
+    private MenuItemEntity menuItem;
+
+    /**
+     * 수량
+     */
+    @Column(name = "quantity")
+    private Integer quantity;
+
+    /**
+     * 가격 (옵션 포함)
+     */
+    @Column(name = "price")
+    private Integer price;
+}

--- a/src/main/java/com/NOK_NOK/order/repository/MenuItemRepository.java
+++ b/src/main/java/com/NOK_NOK/order/repository/MenuItemRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,42 +19,141 @@ import java.util.Optional;
 @Repository
 public interface MenuItemRepository extends JpaRepository<MenuItemEntity, Long> {
 
-        /**
-         * 카테고리별 메뉴 조회 (페이지네이션)
-         */
-        Page<MenuItemEntity> findByCategoryId(Long categoryId, Pageable pageable);
+    // ============================================
+    // 기존 메뉴 조회 쿼리
+    // ============================================
 
-        /**
-         * 카테고리 + 활성화 상태별 메뉴 조회 (페이지네이션)
-         */
-        Page<MenuItemEntity> findByCategoryIdAndIsActive(Long categoryId, Boolean isActive, Pageable pageable);
+    /**
+     * 카테고리별 메뉴 조회 (페이지네이션)
+     */
+    Page<MenuItemEntity> findByCategoryId(Long categoryId, Pageable pageable);
 
-        /**
-         * 카테고리 + 활성화 상태별 메뉴 조회 (정렬만 적용, 키오스크용)
-         */
-        List<MenuItemEntity> findByCategoryIdAndIsActive(Long categoryId, Boolean isActive, Sort sort);
+    /**
+     * 카테고리 + 활성화 상태별 메뉴 조회 (페이지네이션)
+     */
+    Page<MenuItemEntity> findByCategoryIdAndIsActive(Long categoryId, Boolean isActive, Pageable pageable);
 
-        /**
-         * 키워드 검색 (메뉴명)
-         */
-        @Query("SELECT m FROM MenuItemEntity m WHERE " +
-                        "(:categoryId IS NULL OR m.categoryId = :categoryId) AND " +
-                        "(:isActive IS NULL OR m.isActive = :isActive) AND " +
-                        "(:keyword IS NULL OR m.name LIKE %:keyword%)")
-        Page<MenuItemEntity> searchMenus(
-                        @Param("categoryId") Long categoryId,
-                        @Param("isActive") Boolean isActive,
-                        @Param("keyword") String keyword,
-                        Pageable pageable);
+    /**
+     * 카테고리 + 활성화 상태별 메뉴 조회 (정렬만 적용, 키오스크용)
+     */
+    List<MenuItemEntity> findByCategoryIdAndIsActive(Long categoryId, Boolean isActive, Sort sort);
 
-        /**
-         * 메뉴와 옵션 그룹을 함께 조회
-         * 
-         * DISTINCT 추가로 MultipleBagFetchException 해결
-         * 옵션 아이템은 LAZY 로딩으로 자동 조회됨
-         */
-        @Query("SELECT DISTINCT m FROM MenuItemEntity m " +
-                        "LEFT JOIN FETCH m.optionGroups " +
-                        "WHERE m.menuId = :menuId")
-        Optional<MenuItemEntity> findByIdWithOptions(@Param("menuId") Long menuId);
+    /**
+     * 키워드 검색 (메뉴명)
+     */
+    @Query("SELECT m FROM MenuItemEntity m WHERE " +
+            "(:categoryId IS NULL OR m.categoryId = :categoryId) AND " +
+            "(:isActive IS NULL OR m.isActive = :isActive) AND " +
+            "(:keyword IS NULL OR m.name LIKE %:keyword%)")
+    Page<MenuItemEntity> searchMenus(
+            @Param("categoryId") Long categoryId,
+            @Param("isActive") Boolean isActive,
+            @Param("keyword") String keyword,
+            Pageable pageable);
+
+    /**
+     * 메뉴와 옵션 그룹을 함께 조회
+     * 
+     * DISTINCT 추가로 MultipleBagFetchException 해결
+     * 옵션 아이템은 LAZY 로딩으로 자동 조회됨
+     */
+    @Query("SELECT DISTINCT m FROM MenuItemEntity m " +
+            "LEFT JOIN FETCH m.optionGroups " +
+            "WHERE m.menuId = :menuId")
+    Optional<MenuItemEntity> findByIdWithOptions(@Param("menuId") Long menuId);
+
+    // ============================================
+    // ⭐ 추천 메뉴 쿼리 (3단계) - 여기서부터 추가!
+    // ============================================
+
+    /**
+     * 1순위: 시간대 + 성별 + 연령대 기반 추천
+     * 
+     * 대상 인식 성공 시 사용
+     * Native Query 사용 (LIMIT 적용)
+     * 
+     * @param timeSlot  시간대
+     * @param gender    성별
+     * @param ageGroup  연령대
+     * @param startDate 조회 시작 날짜 (최근 3개월)
+     * @param limit     조회 개수
+     * @return [menuId, orderCount] 배열 리스트
+     */
+    @Query(value = "SELECT m.menu_id, COUNT(oi.order_item_id) as order_count " +
+            "FROM customer_session cs " +
+            "JOIN orders o ON cs.session_id = o.session_id " +
+            "JOIN order_item oi ON o.order_id = oi.order_id " +
+            "JOIN menu_item m ON oi.menu_id = m.menu_id " +
+            "WHERE cs.time_slot = :timeSlot " +
+            "  AND cs.gender = :gender " +
+            "  AND cs.age_group = :ageGroup " +
+            "  AND m.is_active = 1 " +
+            "  AND o.created_at >= :startDate " +
+            "GROUP BY m.menu_id " +
+            "ORDER BY order_count DESC " +
+            "LIMIT :limit", nativeQuery = true)
+    List<Object[]> findRecommendedByFullCondition(
+            @Param("timeSlot") String timeSlot,
+            @Param("gender") String gender,
+            @Param("ageGroup") String ageGroup,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("limit") int limit);
+
+    /**
+     * 2순위: 시간대만 기반 추천 (디폴트)
+     * 
+     * 대상 인식 실패 시 사용
+     * Native Query 사용 (LIMIT 적용)
+     * 
+     * @param timeSlot  시간대
+     * @param startDate 조회 시작 날짜
+     * @param limit     조회 개수
+     * @return [menuId, orderCount] 배열 리스트
+     */
+    @Query(value = "SELECT m.menu_id, COUNT(oi.order_item_id) as order_count " +
+            "FROM customer_session cs " +
+            "JOIN orders o ON cs.session_id = o.session_id " +
+            "JOIN order_item oi ON o.order_id = oi.order_id " +
+            "JOIN menu_item m ON oi.menu_id = m.menu_id " +
+            "WHERE cs.time_slot = :timeSlot " +
+            "  AND m.is_active = 1 " +
+            "  AND o.created_at >= :startDate " +
+            "GROUP BY m.menu_id " +
+            "ORDER BY order_count DESC " +
+            "LIMIT :limit", nativeQuery = true)
+    List<Object[]> findRecommendedByTimeSlot(
+            @Param("timeSlot") String timeSlot,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("limit") int limit);
+
+    /**
+     * 3순위: 전체 인기 메뉴 (최후의 디폴트)
+     * 
+     * Native Query 사용 (LIMIT 적용)
+     * 
+     * @param startDate 조회 시작 날짜
+     * @param limit     조회 개수
+     * @return [menuId, orderCount] 배열 리스트
+     */
+    @Query(value = "SELECT m.menu_id, COUNT(oi.order_item_id) as order_count " +
+            "FROM orders o " +
+            "JOIN order_item oi ON o.order_id = oi.order_id " +
+            "JOIN menu_item m ON oi.menu_id = m.menu_id " +
+            "WHERE m.is_active = 1 " +
+            "  AND o.created_at >= :startDate " +
+            "GROUP BY m.menu_id " +
+            "ORDER BY order_count DESC " +
+            "LIMIT :limit", nativeQuery = true)
+    List<Object[]> findPopularMenus(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("limit") int limit);
+
+    /**
+     * 메뉴 ID 리스트로 메뉴 조회
+     * 
+     * @param menuIds 메뉴 ID 리스트
+     * @return 메뉴 목록
+     */
+    @Query("SELECT m FROM MenuItemEntity m WHERE m.menuId IN :menuIds")
+    List<MenuItemEntity> findByMenuIdIn(@Param("menuIds") List<Long> menuIds);
 }

--- a/src/main/java/com/NOK_NOK/order/service/MenuService.java
+++ b/src/main/java/com/NOK_NOK/order/service/MenuService.java
@@ -1,6 +1,5 @@
 package com.NOK_NOK.order.service;
 
-import com.NOK_NOK.order.domain.dto.MenuRequestDto;
 import com.NOK_NOK.order.domain.dto.MenuResponseDto;
 import com.NOK_NOK.order.domain.entity.CategoryEntity;
 import com.NOK_NOK.order.domain.entity.MenuItemEntity;
@@ -13,9 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -24,103 +21,104 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class MenuService {
 
-    private final MenuItemRepository menuItemRepository;
-    private final CategoryRepository categoryRepository;
+        private final MenuItemRepository menuItemRepository;
+        private final CategoryRepository categoryRepository;
 
-    /**
-     * 키오스크용: 전체 카테고리와 각 카테고리별 메뉴 조회
-     * 활성화된 메뉴만 조회
-     */
-    public MenuResponseDto.CategoriesWithMenus getCategoriesWithMenusForKiosk() {
-        log.info("Fetching categories with menus for kiosk");
+        /**
+         * 키오스크용: 전체 카테고리와 각 카테고리별 메뉴 조회
+         * 활성화된 메뉴만 조회
+         */
+        public MenuResponseDto.CategoriesWithMenus getCategoriesWithMenusForKiosk() {
+                log.info("Fetching categories with menus for kiosk");
 
-        // 1. 전체 카테고리 조회 (display_order 순)
-        List<CategoryEntity> categories = categoryRepository.findAllByOrderByDisplayOrderAsc();
+                // 1. 전체 카테고리 조회 (display_order 순)
+                List<CategoryEntity> categories = categoryRepository.findAllByOrderByDisplayOrderAsc();
 
-        // 2. 카테고리별로 활성화된 메뉴 조회
-        int maxMenuCount = 0;
-        List<MenuResponseDto.CategoryWithMenus> categoryWithMenusList = new ArrayList<>();
+                // 2. 카테고리별로 활성화된 메뉴 조회
+                int maxMenuCount = 0;
+                List<MenuResponseDto.CategoryWithMenus> categoryWithMenusList = new ArrayList<>();
 
-        for (CategoryEntity category : categories) {
-            // 해당 카테고리의 활성화된 메뉴만 조회
-            List<MenuItemEntity> menus = menuItemRepository.findByCategoryIdAndIsActive(
-                    category.getCategoryId(),
-                    true,
-                    Sort.by(Sort.Direction.ASC, "menuId"));
+                for (CategoryEntity category : categories) {
+                        // 해당 카테고리의 활성화된 메뉴만 조회
+                        List<MenuItemEntity> menus = menuItemRepository.findByCategoryIdAndIsActive(
+                                        category.getCategoryId(),
+                                        true,
+                                        Sort.by(Sort.Direction.ASC, "menuId"));
 
-            // 메뉴 DTO 변환
-            List<MenuResponseDto.MenuDetail> menuDetails = menus.stream()
-                    .map(menu -> MenuResponseDto.MenuDetail.builder()
-                            .menuId(menu.getMenuId())
-                            .categoryId(menu.getCategoryId())
-                            .categoryName(category.getName())
-                            .name(menu.getName())
-                            .price(menu.getPrice())
-                            .isActive(menu.getIsActive())
-                            .imageUrl(menu.getImageUrl())
-                            .build())
-                    .collect(Collectors.toList());
+                        // 메뉴 DTO 변환
+                        List<MenuResponseDto.MenuDetail> menuDetails = menus.stream()
+                                        .map(menu -> MenuResponseDto.MenuDetail.builder()
+                                                        .menuId(menu.getMenuId())
+                                                        .categoryId(menu.getCategoryId())
+                                                        .categoryName(category.getName())
+                                                        .name(menu.getName())
+                                                        .price(menu.getPrice())
+                                                        .isActive(menu.getIsActive())
+                                                        .imageUrl(menu.getImageUrl())
+                                                        .build())
+                                        .collect(Collectors.toList());
 
-            // 최대 메뉴 개수 갱신
-            if (menuDetails.size() > maxMenuCount) {
-                maxMenuCount = menuDetails.size();
-            }
+                        // 최대 메뉴 개수 갱신
+                        if (menuDetails.size() > maxMenuCount) {
+                                maxMenuCount = menuDetails.size();
+                        }
 
-            // 카테고리별 메뉴 그룹 생성
-            categoryWithMenusList.add(
-                    MenuResponseDto.CategoryWithMenus.builder()
-                            .categoryId(category.getCategoryId())
-                            .categoryName(category.getName())
-                            .displayOrder(category.getDisplayOrder())
-                            .menus(menuDetails)
-                            .menuCount(menuDetails.size())
-                            .build());
+                        // 카테고리별 메뉴 그룹 생성
+                        categoryWithMenusList.add(
+                                        MenuResponseDto.CategoryWithMenus.builder()
+                                                        .categoryId(category.getCategoryId())
+                                                        .categoryName(category.getName())
+                                                        .displayOrder(category.getDisplayOrder())
+                                                        .menus(menuDetails)
+                                                        .menuCount(menuDetails.size())
+                                                        .build());
+                }
+
+                return MenuResponseDto.CategoriesWithMenus.builder()
+                                .categories(categoryWithMenusList)
+                                .totalCategories(categoryWithMenusList.size())
+                                .maxMenusPerCategory(maxMenuCount)
+                                .build();
         }
 
-        return MenuResponseDto.CategoriesWithMenus.builder()
-                .categories(categoryWithMenusList)
-                .totalCategories(categoryWithMenusList.size())
-                .maxMenusPerCategory(maxMenuCount)
-                .build();
-    }
+        /**
+         * 키오스크용: 특정 카테고리의 메뉴만 조회
+         * 
+         * @param categoryId 카테고리 ID
+         */
+        public MenuResponseDto.CategoryWithMenus getMenusByCategory(Long categoryId) {
+                log.info("Fetching menus for category: {}", categoryId);
 
-    /**
-     * 키오스크용: 특정 카테고리의 메뉴만 조회
-     * 
-     * @param categoryId 카테고리 ID
-     */
-    public MenuResponseDto.CategoryWithMenus getMenusByCategory(Long categoryId) {
-        log.info("Fetching menus for category: {}", categoryId);
+                // 카테고리 정보 조회
+                CategoryEntity category = categoryRepository.findById(categoryId)
+                                .orElseThrow(() -> new IllegalArgumentException(
+                                                "Category not found with id: " + categoryId));
 
-        // 카테고리 정보 조회
-        CategoryEntity category = categoryRepository.findById(categoryId)
-                .orElseThrow(() -> new IllegalArgumentException("Category not found with id: " + categoryId));
+                // 해당 카테고리의 활성화된 메뉴 조회
+                List<MenuItemEntity> menus = menuItemRepository.findByCategoryIdAndIsActive(
+                                categoryId,
+                                true,
+                                Sort.by(Sort.Direction.ASC, "menuId"));
 
-        // 해당 카테고리의 활성화된 메뉴 조회
-        List<MenuItemEntity> menus = menuItemRepository.findByCategoryIdAndIsActive(
-                categoryId,
-                true,
-                Sort.by(Sort.Direction.ASC, "menuId"));
+                // 메뉴 DTO 변환
+                List<MenuResponseDto.MenuDetail> menuDetails = menus.stream()
+                                .map(menu -> MenuResponseDto.MenuDetail.builder()
+                                                .menuId(menu.getMenuId())
+                                                .categoryId(menu.getCategoryId())
+                                                .categoryName(category.getName())
+                                                .name(menu.getName())
+                                                .price(menu.getPrice())
+                                                .isActive(menu.getIsActive())
+                                                .imageUrl(menu.getImageUrl())
+                                                .build())
+                                .collect(Collectors.toList());
 
-        // 메뉴 DTO 변환
-        List<MenuResponseDto.MenuDetail> menuDetails = menus.stream()
-                .map(menu -> MenuResponseDto.MenuDetail.builder()
-                        .menuId(menu.getMenuId())
-                        .categoryId(menu.getCategoryId())
-                        .categoryName(category.getName())
-                        .name(menu.getName())
-                        .price(menu.getPrice())
-                        .isActive(menu.getIsActive())
-                        .imageUrl(menu.getImageUrl())
-                        .build())
-                .collect(Collectors.toList());
-
-        return MenuResponseDto.CategoryWithMenus.builder()
-                .categoryId(category.getCategoryId())
-                .categoryName(category.getName())
-                .displayOrder(category.getDisplayOrder())
-                .menus(menuDetails)
-                .menuCount(menuDetails.size())
-                .build();
-    }
+                return MenuResponseDto.CategoryWithMenus.builder()
+                                .categoryId(category.getCategoryId())
+                                .categoryName(category.getName())
+                                .displayOrder(category.getDisplayOrder())
+                                .menus(menuDetails)
+                                .menuCount(menuDetails.size())
+                                .build();
+        }
 }

--- a/src/main/java/com/NOK_NOK/order/service/RecommendService.java
+++ b/src/main/java/com/NOK_NOK/order/service/RecommendService.java
@@ -1,0 +1,234 @@
+package com.NOK_NOK.order.service;
+
+import com.NOK_NOK.order.domain.dto.RecommendRequestDto;
+import com.NOK_NOK.order.domain.dto.RecommendResponseDto;
+import com.NOK_NOK.order.domain.entity.CategoryEntity;
+import com.NOK_NOK.order.domain.entity.MenuItemEntity;
+import com.NOK_NOK.order.repository.CategoryRepository;
+import com.NOK_NOK.order.repository.MenuItemRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 추천 메뉴 서비스
+ * 
+ * 3단계 추천 로직:
+ * 1순위: 시간대 + 성별 + 연령대 (대상 인식 성공)
+ * 2순위: 시간대만 (디폴트 - 대상 인식 실패)
+ * 3순위: 전체 인기 메뉴 (최후의 대안)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecommendService {
+
+    private final MenuItemRepository menuItemRepository;
+    private final CategoryRepository categoryRepository;
+
+    /**
+     * 추천 메뉴 조회
+     * 
+     * @param request 추천 조건
+     * @return 추천 메뉴 목록
+     */
+    public RecommendResponseDto.RecommendList getRecommendedMenus(RecommendRequestDto.Recommend request) {
+        log.info("[추천 메뉴 조회] 시작 - timeSlot: {}, gender: {}, ageGroup: {}",
+                request.getTimeSlot(), request.getGender(), request.getAgeGroup());
+
+        // 최근 3개월 데이터 기준
+        LocalDateTime startDate = LocalDateTime.now().minusMonths(3);
+
+        // 3단계 추천 로직
+        RecommendResult result = getRecommendedMenusWithFallback(
+                request.getTimeSlot(),
+                request.getGender(),
+                request.getAgeGroup(),
+                startDate,
+                request.getLimit());
+
+        // 카테고리 정보 조회 (N+1 방지)
+        Map<Long, String> categoryNameMap = getCategoryNameMap();
+
+        // DTO 변환
+        List<RecommendResponseDto.RecommendedMenu> recommendedMenus = convertToRecommendedMenus(result, categoryNameMap,
+                request);
+
+        log.info("[추천 메뉴 조회] 완료 - 추천 타입: {}, 메뉴 개수: {}",
+                result.type, recommendedMenus.size());
+
+        return RecommendResponseDto.RecommendList.builder()
+                .timeSlot(request.getTimeSlot())
+                .gender(request.getGender())
+                .ageGroup(request.getAgeGroup())
+                .recommendedMenus(recommendedMenus)
+                .totalCount(recommendedMenus.size())
+                .recommendType(result.type)
+                .build();
+    }
+
+    /**
+     * 3단계 폴백 추천 로직
+     */
+    private RecommendResult getRecommendedMenusWithFallback(
+            String timeSlot, String gender, String ageGroup,
+            LocalDateTime startDate, int limit) {
+
+        // 1순위: 시간대 + 성별 + 연령대
+        if (gender != null && ageGroup != null) {
+            log.info("[1순위] 시간대 + 성별 + 연령대 기반 조회 시도");
+            List<Object[]> result = menuItemRepository.findRecommendedByFullCondition(
+                    timeSlot, gender, ageGroup, startDate, limit);
+
+            if (!result.isEmpty()) {
+                log.info("[1순위] 성공 - {} 개 메뉴 발견", result.size());
+                return new RecommendResult(result, "FULL");
+            }
+            log.info("[1순위] 실패 - 데이터 없음, 2순위로 이동");
+        }
+
+        // 2순위: 시간대만 (디폴트)
+        log.info("[2순위] 시간대만 기반 조회 시도");
+        List<Object[]> result = menuItemRepository.findRecommendedByTimeSlot(
+                timeSlot, startDate, limit);
+
+        if (!result.isEmpty()) {
+            log.info("[2순위] 성공 - {} 개 메뉴 발견", result.size());
+            return new RecommendResult(result, "TIME_ONLY");
+        }
+        log.info("[2순위] 실패 - 데이터 없음, 3순위로 이동");
+
+        // 3순위: 전체 인기 메뉴
+        log.info("[3순위] 전체 인기 메뉴 조회");
+        result = menuItemRepository.findPopularMenus(startDate, limit);
+        log.info("[3순위] 완료 - {} 개 메뉴 발견", result.size());
+
+        return new RecommendResult(result, "POPULAR");
+    }
+
+    /**
+     * 카테고리 ID -> 이름 매핑 생성
+     */
+    private Map<Long, String> getCategoryNameMap() {
+        List<CategoryEntity> categories = categoryRepository.findAll();
+        Map<Long, String> categoryNameMap = new HashMap<>();
+
+        for (CategoryEntity category : categories) {
+            categoryNameMap.put(category.getCategoryId(), category.getName());
+        }
+
+        return categoryNameMap;
+    }
+
+    /**
+     * RecommendResult -> RecommendedMenu DTO 변환
+     */
+    private List<RecommendResponseDto.RecommendedMenu> convertToRecommendedMenus(
+            RecommendResult result,
+            Map<Long, String> categoryNameMap,
+            RecommendRequestDto.Recommend request) {
+
+        // Object[] -> Map 변환 (menuId -> orderCount)
+        Map<Long, Long> orderCountMap = new LinkedHashMap<>();
+        for (Object[] row : result.data) {
+            Long menuId = ((Number) row[0]).longValue();
+            Long orderCount = ((Number) row[1]).longValue();
+            orderCountMap.put(menuId, orderCount);
+        }
+
+        // 메뉴 ID 리스트
+        List<Long> menuIds = new ArrayList<>(orderCountMap.keySet());
+
+        if (menuIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 메뉴 정보 조회
+        List<MenuItemEntity> menus = menuItemRepository.findByMenuIdIn(menuIds);
+
+        // menuId -> MenuItemEntity 매핑
+        Map<Long, MenuItemEntity> menuMap = menus.stream()
+                .collect(Collectors.toMap(MenuItemEntity::getMenuId, menu -> menu));
+
+        // DTO 변환
+        List<RecommendResponseDto.RecommendedMenu> recommendedMenus = new ArrayList<>();
+        int rank = 1;
+
+        for (Long menuId : menuIds) {
+            MenuItemEntity menu = menuMap.get(menuId);
+            if (menu == null)
+                continue;
+
+            Long orderCount = orderCountMap.get(menuId);
+
+            recommendedMenus.add(
+                    RecommendResponseDto.RecommendedMenu.builder()
+                            .menuId(menu.getMenuId())
+                            .menuName(menu.getName())
+                            .categoryName(categoryNameMap.get(menu.getCategoryId()))
+                            .basePrice(menu.getPrice())
+                            .imageUrl(menu.getImageUrl())
+                            .orderCount(orderCount)
+                            .popularRank(rank++)
+                            .recommendReason(buildRecommendReason(result.type, request, rank - 1))
+                            .build());
+        }
+
+        return recommendedMenus;
+    }
+
+    /**
+     * 추천 이유 생성
+     */
+    private String buildRecommendReason(String type, RecommendRequestDto.Recommend request, int rank) {
+        String timeText = getTimeSlotText(request.getTimeSlot());
+
+        switch (type) {
+            case "FULL":
+                String genderText = "MALE".equals(request.getGender()) ? "남성" : "여성";
+                return String.format("%s %s %s에게 인기 %d위",
+                        timeText, request.getAgeGroup(), genderText, rank);
+            case "TIME_ONLY":
+                return String.format("%s 시간대 인기 %d위", timeText, rank);
+            case "POPULAR":
+                return String.format("전체 인기 %d위", rank);
+            default:
+                return String.format("추천 메뉴 %d위", rank);
+        }
+    }
+
+    /**
+     * 시간대 텍스트 변환
+     */
+    private String getTimeSlotText(String timeSlot) {
+        switch (timeSlot) {
+            case "MORNING":
+                return "아침";
+            case "AFTERNOON":
+                return "오후";
+            case "EVENING":
+                return "저녁";
+            default:
+                return "";
+        }
+    }
+
+    /**
+     * 추천 결과 내부 클래스
+     */
+    private static class RecommendResult {
+        List<Object[]> data; // [menuId, orderCount]
+        String type; // FULL, TIME_ONLY, POPULAR
+
+        RecommendResult(List<Object[]> data, String type) {
+            this.data = data;
+            this.type = type;
+        }
+    }
+}


### PR DESCRIPTION
## 메뉴 추천 API 구현

**API:** `GET /api/menus/recommend`

### 구현 내용
* 3단계 추천 로직 (대상인식 성공/실패 대응)
* 과거 주문 데이터 기반 통계
* Native Query + LIMIT 사용

### 파일
* Entity 3개 (CustomerSession, Order, OrderItem)
* DTO 2개, Repository/Service/Controller 각 1개

### 테스트
- [x] Swagger UI 완료 ✅