### PR TITLE
Feat 4.3.1 ads

### DIFF
--- a/src/main/java/com/NOK_NOK/abs/controller/AdController.java
+++ b/src/main/java/com/NOK_NOK/abs/controller/AdController.java
@@ -102,7 +102,7 @@ public class AdController {
             @RequestBody AdRequestDto.SaveDisplayLog request) {
 
         log.info("[API] POST /api/ads/display-log - sessionId: {}, adId: {}",
-                request.getSessionId(), request.getAdId());
+                /*request.getSessionId(),*/ request.getAdId());
 
         AdResponseDto.DisplayLogSaved response = adService.saveDisplayLog(request);
 

--- a/src/main/java/com/NOK_NOK/abs/controller/AdController.java
+++ b/src/main/java/com/NOK_NOK/abs/controller/AdController.java
@@ -55,26 +55,30 @@ public class AdController {
     /**
      * 결제 후 맞춤형 광고 조회
      * 
-     * API: GET /api/ads/payment?sessionId=1
+     * API: GET /api/ads/payment?ageGroup=20대&gender=M
      * 
-     * 결제 완료 후 세션의 연령대, 성별 정보를 기반으로 타겟팅된 광고 제공
-     * React에서 정해진 시간 동안 표시 후 POST /api/ads/display-log 호출
+     * Frontend에서 저장하고 있던 대상 인식 정보를 파라미터로 전달
+     * 해당 조건에 맞는 광고를 타겟팅하여 제공
      * 
-     * @param sessionId 세션 ID
+     * @param ageGroup 연령대 (선택, Frontend에서 전달)
+     * @param gender 성별 (선택, Frontend에서 전달)
      * @return 맞춤형 광고 목록
      */
     @Operation(
         summary = "결제 후 맞춤형 광고 조회",
-        description = "세션의 연령대, 성별 정보를 기반으로 타겟팅된 광고를 조회합니다."
+        description = "Frontend에서 저장하고 있던 대상 인식 정보(연령대, 성별)를 기반으로 타겟팅된 광고를 제공합니다."
     )
     @GetMapping("/payment")
     public ResponseEntity<AdResponseDto.PaymentAdList> getPaymentAds(
-            @Parameter(description = "세션 ID", example = "1", required = true)
-            @RequestParam("sessionId") Long sessionId) {
+            @Parameter(description = "연령대 (예: 20대, 30대)", example = "20대")
+            @RequestParam(value = "ageGroup", required = false) String ageGroup,
+            
+            @Parameter(description = "성별 (M: 남성, F: 여성)", example = "M")
+            @RequestParam(value = "gender", required = false) String gender) {
 
-        log.info("[API] GET /api/ads/payment - sessionId: {}", sessionId);
+        log.info("[API] GET /api/ads/payment - ageGroup: {}, gender: {}", ageGroup, gender);
 
-        AdResponseDto.PaymentAdList response = adService.getPaymentAds(sessionId);
+        AdResponseDto.PaymentAdList response = adService.getPaymentAds(ageGroup, gender);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/NOK_NOK/abs/controller/AdController.java
+++ b/src/main/java/com/NOK_NOK/abs/controller/AdController.java
@@ -1,0 +1,107 @@
+package com.NOK_NOK.abs.controller;
+
+import com.NOK_NOK.abs.domain.dto.AdRequestDto;
+import com.NOK_NOK.abs.domain.dto.AdResponseDto;
+import com.NOK_NOK.abs.service.AdService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 광고 컨트롤러
+ * 
+ * API:
+ * 1. GET /api/ads - 전체 활성화 광고 조회
+ * 2. GET /api/ads/payment - 결제 후 맞춤형 광고 조회
+ * 3. POST /api/ads/display-log - 광고 표시 로그 저장
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/ads")
+@RequiredArgsConstructor
+@Tag(name = "Advertisement", description = "광고 관리 API")
+public class AdController {
+
+    private final AdService adService;
+
+    /**
+     * 전체 활성화 광고 조회
+     * 
+     * API: GET /api/ads
+     * 
+     * 메인 화면에서 모든 광고를 React로 전달
+     * React에서 정해진 로직에 따라 순서대로 표시
+     * 각 광고가 끝나면 POST /api/ads/display-log 호출
+     * 
+     * @return 활성화된 광고 목록
+     */
+    @Operation(
+        summary = "전체 광고 조회",
+        description = "메인 화면용 활성화된 모든 광고를 조회합니다. React에서 순서대로 표시합니다."
+    )
+    @GetMapping
+    public ResponseEntity<AdResponseDto.AdList> getAllActiveAds() {
+        log.info("[API] GET /api/ads - 전체 광고 조회");
+
+        AdResponseDto.AdList response = adService.getAllActiveAds();
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 결제 후 맞춤형 광고 조회
+     * 
+     * API: GET /api/ads/payment?sessionId=1
+     * 
+     * 결제 완료 후 세션의 연령대, 성별 정보를 기반으로 타겟팅된 광고 제공
+     * React에서 정해진 시간 동안 표시 후 POST /api/ads/display-log 호출
+     * 
+     * @param sessionId 세션 ID
+     * @return 맞춤형 광고 목록
+     */
+    @Operation(
+        summary = "결제 후 맞춤형 광고 조회",
+        description = "세션의 연령대, 성별 정보를 기반으로 타겟팅된 광고를 조회합니다."
+    )
+    @GetMapping("/payment")
+    public ResponseEntity<AdResponseDto.PaymentAdList> getPaymentAds(
+            @Parameter(description = "세션 ID", example = "1", required = true)
+            @RequestParam("sessionId") Long sessionId) {
+
+        log.info("[API] GET /api/ads/payment - sessionId: {}", sessionId);
+
+        AdResponseDto.PaymentAdList response = adService.getPaymentAds(sessionId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 광고 표시 로그 저장
+     * 
+     * API: POST /api/ads/display-log
+     * 
+     * React에서 광고가 끝나면 호출하여 로그 저장
+     * 
+     * @param request 광고 로그 요청
+     * @return 저장 결과
+     */
+    @Operation(
+        summary = "광고 표시 로그 저장",
+        description = "광고가 표시된 정보를 로그로 저장합니다. React에서 광고가 끝나면 호출합니다."
+    )
+    @PostMapping("/display-log")
+    public ResponseEntity<AdResponseDto.DisplayLogSaved> saveDisplayLog(
+            @RequestBody AdRequestDto.SaveDisplayLog request) {
+
+        log.info("[API] POST /api/ads/display-log - sessionId: {}, adId: {}",
+                request.getSessionId(), request.getAdId());
+
+        AdResponseDto.DisplayLogSaved response = adService.saveDisplayLog(request);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/NOK_NOK/abs/controller/advice/AdExceptionHandler.java
+++ b/src/main/java/com/NOK_NOK/abs/controller/advice/AdExceptionHandler.java
@@ -1,0 +1,100 @@
+package com.NOK_NOK.abs.controller.advice;
+
+import com.NOK_NOK.abs.exceptions.AdExceptions.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+/**
+ * 광고 예외 처리
+ */
+@Slf4j
+@RestControllerAdvice(basePackages = "com.NOK_NOK.abs")
+public class AdExceptionHandler {
+
+    /**
+     * 광고를 찾을 수 없음
+     */
+    @ExceptionHandler(AdNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleAdNotFound(AdNotFoundException e) {
+        log.error("[예외] AdNotFoundException: {}", e.getMessage());
+        
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.NOT_FOUND.value())
+                .error("Ad Not Found")
+                .message(e.getMessage())
+                .build();
+        
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
+    /**
+     * 세션을 찾을 수 없음
+     */
+    @ExceptionHandler(SessionNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleSessionNotFound(SessionNotFoundException e) {
+        log.error("[예외] SessionNotFoundException: {}", e.getMessage());
+        
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.NOT_FOUND.value())
+                .error("Session Not Found")
+                .message(e.getMessage())
+                .build();
+        
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
+    /**
+     * 활성화된 광고가 없음
+     */
+    @ExceptionHandler(NoActiveAdsException.class)
+    public ResponseEntity<ErrorResponse> handleNoActiveAds(NoActiveAdsException e) {
+        log.warn("[예외] NoActiveAdsException: {}", e.getMessage());
+        
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.NOT_FOUND.value())
+                .error("No Active Ads")
+                .message(e.getMessage())
+                .build();
+        
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
+    /**
+     * 잘못된 광고 로그 요청
+     */
+    @ExceptionHandler(InvalidDisplayLogRequestException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidDisplayLogRequest(InvalidDisplayLogRequestException e) {
+        log.error("[예외] InvalidDisplayLogRequestException: {}", e.getMessage());
+        
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .error("Invalid Display Log Request")
+                .message(e.getMessage())
+                .build();
+        
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    /**
+     * 에러 응답 DTO
+     */
+    @lombok.Getter
+    @lombok.Builder
+    @lombok.NoArgsConstructor
+    @lombok.AllArgsConstructor
+    public static class ErrorResponse {
+        private LocalDateTime timestamp;
+        private Integer status;
+        private String error;
+        private String message;
+    }
+}

--- a/src/main/java/com/NOK_NOK/abs/domain/dto/AdRequestDto.java
+++ b/src/main/java/com/NOK_NOK/abs/domain/dto/AdRequestDto.java
@@ -53,7 +53,7 @@ public class AdRequestDto {
         /**
          * 세션 ID
          */
-        private Long sessionId;
+        // private Long sessionId;
 
         /**
          * 광고 ID

--- a/src/main/java/com/NOK_NOK/abs/domain/dto/AdRequestDto.java
+++ b/src/main/java/com/NOK_NOK/abs/domain/dto/AdRequestDto.java
@@ -1,0 +1,63 @@
+package com.NOK_NOK.abs.domain.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * 광고 요청 DTO
+ */
+public class AdRequestDto {
+
+    /**
+     * 결제 후 맞춤형 광고 조회 요청
+     * 
+     * API: GET /api/ads/payment?sessionId=1
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PaymentAdRequest {
+        
+        /**
+         * 세션 ID (연령대, 성별 정보 포함)
+         */
+        private Long sessionId;
+    }
+
+    /**
+     * 광고 표시 로그 저장 요청
+     * 
+     * API: POST /api/ads/display-log
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SaveDisplayLog {
+        
+        /**
+         * 세션 ID
+         */
+        private Long sessionId;
+
+        /**
+         * 광고 ID
+         */
+        private Long adId;
+
+        /**
+         * 표시 시작 시간
+         * ISO 8601 형식: "2023-12-11T14:30:00"
+         */
+        private LocalDateTime displayedAt;
+
+        /**
+         * 노출 시간 (밀리초)
+         */
+        private Integer durationMs;
+    }
+}

--- a/src/main/java/com/NOK_NOK/abs/domain/dto/AdRequestDto.java
+++ b/src/main/java/com/NOK_NOK/abs/domain/dto/AdRequestDto.java
@@ -12,7 +12,9 @@ public class AdRequestDto {
     /**
      * 결제 후 맞춤형 광고 조회 요청
      * 
-     * API: GET /api/ads/payment?sessionId=1
+     * API: GET /api/ads/payment?ageGroup=20대&gender=M
+     * 
+     * Frontend에서 저장하고 있던 대상 인식 정보를 파라미터로 전달
      */
     @Getter
     @Setter
@@ -22,9 +24,18 @@ public class AdRequestDto {
     public static class PaymentAdRequest {
         
         /**
-         * 세션 ID (연령대, 성별 정보 포함)
+         * 연령대 (선택)
+         * 예: "10대", "20대", "30대", "40대", "50대+"
+         * NULL: 대상 인식 실패 → 일반 광고
          */
-        private Long sessionId;
+        private String ageGroup;
+
+        /**
+         * 성별 (선택)
+         * M: 남성, F: 여성
+         * NULL: 대상 인식 실패 → 일반 광고
+         */
+        private String gender;
     }
 
     /**

--- a/src/main/java/com/NOK_NOK/abs/domain/dto/AdResponseDto.java
+++ b/src/main/java/com/NOK_NOK/abs/domain/dto/AdResponseDto.java
@@ -111,7 +111,7 @@ public class AdResponseDto {
     /**
      * 결제 후 맞춤형 광고 응답
      * 
-     * API: GET /api/ads/payment?sessionId=1
+     * API: GET /api/ads/payment?ageGroup=20대&gender=M
      */
     @Getter
     @Builder

--- a/src/main/java/com/NOK_NOK/abs/domain/dto/AdResponseDto.java
+++ b/src/main/java/com/NOK_NOK/abs/domain/dto/AdResponseDto.java
@@ -160,7 +160,7 @@ public class AdResponseDto {
         /**
          * 세션 ID
          */
-        private Long sessionId;
+        // private Long sessionId;
 
         /**
          * 광고 ID

--- a/src/main/java/com/NOK_NOK/abs/domain/dto/AdResponseDto.java
+++ b/src/main/java/com/NOK_NOK/abs/domain/dto/AdResponseDto.java
@@ -1,0 +1,185 @@
+package com.NOK_NOK.abs.domain.dto;
+
+import com.NOK_NOK.abs.domain.entity.AdContentEntity;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 광고 응답 DTO
+ */
+public class AdResponseDto {
+
+    /**
+     * 광고 목록 응답
+     * 
+     * API: GET /api/ads
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AdList {
+        
+        /**
+         * 광고 목록
+         */
+        private List<AdDetail> ads;
+
+        /**
+         * 총 광고 개수
+         */
+        private Integer totalCount;
+
+        /**
+         * Entity List → DTO 변환
+         */
+        public static AdList from(List<AdContentEntity> adContents) {
+            List<AdDetail> ads = adContents.stream()
+                    .map(AdDetail::from)
+                    .collect(Collectors.toList());
+            
+            return AdList.builder()
+                    .ads(ads)
+                    .totalCount(ads.size())
+                    .build();
+        }
+    }
+
+    /**
+     * 광고 상세 정보
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AdDetail {
+        
+        /**
+         * 광고 ID
+         */
+        private Long adId;
+
+        /**
+         * 광고 이름
+         */
+        private String title;
+
+        /**
+         * 미디어 타입 (IMAGE, VIDEO)
+         */
+        private String mediaType;
+
+        /**
+         * 미디어 URL
+         */
+        private String mediaUrl;
+
+        /**
+         * 광고 시작 날짜
+         */
+        private LocalDate startDate;
+
+        /**
+         * 광고 종료 날짜
+         */
+        private LocalDate endDate;
+
+        /**
+         * 활성화 여부
+         */
+        private Boolean isActive;
+
+        /**
+         * Entity → DTO 변환
+         */
+        public static AdDetail from(AdContentEntity adContent) {
+            return AdDetail.builder()
+                    .adId(adContent.getAdId())
+                    .title(adContent.getTitle())
+                    .mediaType(adContent.getMediaType())
+                    .mediaUrl(adContent.getMediaUrl())
+                    .startDate(adContent.getStartDate())
+                    .endDate(adContent.getEndDate())
+                    .isActive(adContent.getIsActive())
+                    .build();
+        }
+    }
+
+    /**
+     * 결제 후 맞춤형 광고 응답
+     * 
+     * API: GET /api/ads/payment?sessionId=1
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PaymentAdList {
+        
+        /**
+         * 타겟팅된 광고 목록
+         */
+        private List<AdDetail> ads;
+
+        /**
+         * 총 광고 개수
+         */
+        private Integer totalCount;
+
+        /**
+         * 타겟팅 정보
+         */
+        private String ageGroup;
+        private String gender;
+
+        /**
+         * 메시지
+         */
+        private String message;
+    }
+
+    /**
+     * 광고 표시 로그 저장 응답
+     * 
+     * API: POST /api/ads/display-log
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DisplayLogSaved {
+        
+        /**
+         * 로그 ID
+         */
+        private Long displayId;
+
+        /**
+         * 세션 ID
+         */
+        private Long sessionId;
+
+        /**
+         * 광고 ID
+         */
+        private Long adId;
+
+        /**
+         * 광고 제목
+         */
+        private String adTitle;
+
+        /**
+         * 노출 시간 (밀리초)
+         */
+        private Integer durationMs;
+
+        /**
+         * 메시지
+         */
+        private String message;
+    }
+}

--- a/src/main/java/com/NOK_NOK/abs/domain/entity/AdContentEntity.java
+++ b/src/main/java/com/NOK_NOK/abs/domain/entity/AdContentEntity.java
@@ -1,0 +1,83 @@
+package com.NOK_NOK.abs.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+/**
+ * 광고 컨텐츠 Entity
+ * 
+ * 테이블: ad_content
+ */
+@Entity
+@Table(name = "ad_content")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AdContentEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ad_id")
+    private Long adId;
+
+    /**
+     * 광고 이름
+     */
+    @Column(name = "title", nullable = false, length = 50)
+    private String title;
+
+    /**
+     * 미디어 타입
+     * IMAGE, VIDEO
+     */
+    @Column(name = "media_type", nullable = false, length = 20)
+    private String mediaType;
+
+    /**
+     * 미디어 URL (광고 원본 경로)
+     */
+    @Column(name = "media_url", nullable = false, length = 255)
+    private String mediaUrl;
+
+    /**
+     * 광고 계약 시작 날짜
+     */
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    /**
+     * 광고 계약 종료 날짜
+     */
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    /**
+     * 사용 여부
+     */
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+
+    /**
+     * 광고가 활성화 기간인지 확인
+     */
+    public boolean isInActivePeriod() {
+        if (!isActive) {
+            return false;
+        }
+        
+        LocalDate now = LocalDate.now();
+        
+        if (startDate != null && now.isBefore(startDate)) {
+            return false;
+        }
+        
+        if (endDate != null && now.isAfter(endDate)) {
+            return false;
+        }
+        
+        return true;
+    }
+}

--- a/src/main/java/com/NOK_NOK/abs/domain/entity/AdDisplayLogEntity.java
+++ b/src/main/java/com/NOK_NOK/abs/domain/entity/AdDisplayLogEntity.java
@@ -1,6 +1,6 @@
 package com.NOK_NOK.abs.domain.entity;
 
-import com.NOK_NOK.order.domain.entity.CustomerSessionEntity;
+// import com.NOK_NOK.order.domain.entity.CustomerSessionEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -24,12 +24,12 @@ public class AdDisplayLogEntity {
     @Column(name = "display_id")
     private Long displayId;
 
-    /**
-     * 고객 세션
-     */
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "session_id", nullable = false)
-    private CustomerSessionEntity session;
+    // /**
+    //  * 고객 세션
+    //  */
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "session_id", nullable = false)
+    // private CustomerSessionEntity session;
 
     /**
      * 광고 컨텐츠

--- a/src/main/java/com/NOK_NOK/abs/domain/entity/AdDisplayLogEntity.java
+++ b/src/main/java/com/NOK_NOK/abs/domain/entity/AdDisplayLogEntity.java
@@ -1,0 +1,52 @@
+package com.NOK_NOK.abs.domain.entity;
+
+import com.NOK_NOK.order.domain.entity.CustomerSessionEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * 광고 표시 로그 Entity
+ * 
+ * 테이블: ad_display_log
+ */
+@Entity
+@Table(name = "ad_display_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AdDisplayLogEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "display_id")
+    private Long displayId;
+
+    /**
+     * 고객 세션
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private CustomerSessionEntity session;
+
+    /**
+     * 광고 컨텐츠
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ad_id", nullable = false)
+    private AdContentEntity adContent;
+
+    /**
+     * 표시 시작 시간
+     */
+    @Column(name = "displayed_at", nullable = false)
+    private LocalDateTime displayedAt;
+
+    /**
+     * 노출 시간 (밀리초)
+     */
+    @Column(name = "duration_ms")
+    private Integer durationMs;
+}

--- a/src/main/java/com/NOK_NOK/abs/domain/entity/AdTargetRuleEntity.java
+++ b/src/main/java/com/NOK_NOK/abs/domain/entity/AdTargetRuleEntity.java
@@ -1,0 +1,77 @@
+package com.NOK_NOK.abs.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 광고 타겟 규칙 Entity
+ * 
+ * 테이블: ad_target_rule
+ */
+@Entity
+@Table(name = "ad_target_rule")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AdTargetRuleEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "rule_id")
+    private Long ruleId;
+
+    /**
+     * 광고 컨텐츠
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ad_id", nullable = false)
+    private AdContentEntity adContent;
+
+    /**
+     * 타겟 나이대
+     * 예: "10대", "20대", "30대", "40대", "50대+"
+     * NULL: 모든 연령대
+     */
+    @Column(name = "age_group", length = 20)
+    private String ageGroup;
+
+    /**
+     * 타겟 성별
+     * M: 남성, F: 여성
+     * NULL: 모든 성별
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender", length = 1)
+    private Gender gender;
+
+    /**
+     * 성별 enum
+     */
+    public enum Gender {
+        M, F
+    }
+
+    /**
+     * 타겟 조건과 매칭되는지 확인
+     * 
+     * @param userAgeGroup 사용자 연령대
+     * @param userGender 사용자 성별
+     * @return 매칭 여부
+     */
+    public boolean matches(String userAgeGroup, String userGender) {
+        // age_group이 NULL이면 모든 연령대 매칭
+        if (this.ageGroup != null && !this.ageGroup.equals(userAgeGroup)) {
+            return false;
+        }
+        
+        // gender가 NULL이면 모든 성별 매칭
+        if (this.gender != null && userGender != null) {
+            if (!this.gender.name().equals(userGender)) {
+                return false;
+            }
+        }
+        
+        return true;
+    }
+}

--- a/src/main/java/com/NOK_NOK/abs/exceptions/AdExceptions.java
+++ b/src/main/java/com/NOK_NOK/abs/exceptions/AdExceptions.java
@@ -1,0 +1,43 @@
+package com.NOK_NOK.abs.exceptions;
+
+/**
+ * 광고 관련 Exception
+ */
+public class AdExceptions {
+
+    /**
+     * 광고를 찾을 수 없음
+     */
+    public static class AdNotFoundException extends RuntimeException {
+        public AdNotFoundException(Long adId) {
+            super(String.format("광고를 찾을 수 없습니다. adId: %d", adId));
+        }
+    }
+
+    /**
+     * 세션을 찾을 수 없음
+     */
+    public static class SessionNotFoundException extends RuntimeException {
+        public SessionNotFoundException(Long sessionId) {
+            super(String.format("세션을 찾을 수 없습니다. sessionId: %d", sessionId));
+        }
+    }
+
+    /**
+     * 활성화된 광고가 없음
+     */
+    public static class NoActiveAdsException extends RuntimeException {
+        public NoActiveAdsException() {
+            super("활성화된 광고가 없습니다.");
+        }
+    }
+
+    /**
+     * 잘못된 광고 로그 요청
+     */
+    public static class InvalidDisplayLogRequestException extends RuntimeException {
+        public InvalidDisplayLogRequestException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/com/NOK_NOK/abs/repository/AdContentRepository.java
+++ b/src/main/java/com/NOK_NOK/abs/repository/AdContentRepository.java
@@ -1,0 +1,29 @@
+package com.NOK_NOK.abs.repository;
+
+import com.NOK_NOK.abs.domain.entity.AdContentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * AdContent Repository
+ */
+@Repository
+public interface AdContentRepository extends JpaRepository<AdContentEntity, Long> {
+
+    /**
+     * 활성화된 모든 광고 조회
+     * 
+     * @param today 오늘 날짜
+     * @return 활성화된 광고 목록
+     */
+    @Query("SELECT ac FROM AdContentEntity ac " +
+           "WHERE ac.isActive = true " +
+           "AND (ac.startDate IS NULL OR ac.startDate <= :today) " +
+           "AND (ac.endDate IS NULL OR ac.endDate >= :today)")
+    List<AdContentEntity> findAllActiveAds(@Param("today") LocalDate today);
+}

--- a/src/main/java/com/NOK_NOK/abs/repository/AdDisplayLogRepository.java
+++ b/src/main/java/com/NOK_NOK/abs/repository/AdDisplayLogRepository.java
@@ -1,0 +1,13 @@
+package com.NOK_NOK.abs.repository;
+
+import com.NOK_NOK.abs.domain.entity.AdDisplayLogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * AdDisplayLog Repository
+ */
+@Repository
+public interface AdDisplayLogRepository extends JpaRepository<AdDisplayLogEntity, Long> {
+    
+}

--- a/src/main/java/com/NOK_NOK/abs/repository/AdTargetRuleRepository.java
+++ b/src/main/java/com/NOK_NOK/abs/repository/AdTargetRuleRepository.java
@@ -1,0 +1,36 @@
+package com.NOK_NOK.abs.repository;
+
+import com.NOK_NOK.abs.domain.entity.AdTargetRuleEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * AdTargetRule Repository
+ */
+@Repository
+public interface AdTargetRuleRepository extends JpaRepository<AdTargetRuleEntity, Long> {
+
+    /**
+     * 특정 광고의 타겟 규칙 조회
+     * 
+     * @param adId 광고 ID
+     * @return 타겟 규칙 목록
+     */
+    @Query("SELECT atr FROM AdTargetRuleEntity atr " +
+           "WHERE atr.adContent.adId = :adId")
+    List<AdTargetRuleEntity> findByAdId(@Param("adId") Long adId);
+
+    /**
+     * 광고 ID 목록으로 타겟 규칙 일괄 조회
+     * 
+     * @param adIds 광고 ID 목록
+     * @return 타겟 규칙 목록
+     */
+    @Query("SELECT atr FROM AdTargetRuleEntity atr " +
+           "WHERE atr.adContent.adId IN :adIds")
+    List<AdTargetRuleEntity> findByAdIdIn(@Param("adIds") List<Long> adIds);
+}

--- a/src/main/java/com/NOK_NOK/abs/service/AdService.java
+++ b/src/main/java/com/NOK_NOK/abs/service/AdService.java
@@ -9,8 +9,8 @@ import com.NOK_NOK.abs.exceptions.AdExceptions.*;
 import com.NOK_NOK.abs.repository.AdContentRepository;
 import com.NOK_NOK.abs.repository.AdDisplayLogRepository;
 import com.NOK_NOK.abs.repository.AdTargetRuleRepository;
-import com.NOK_NOK.order.domain.entity.CustomerSessionEntity;
-import com.NOK_NOK.order.repository.CustomerSessionRepository;
+// import com.NOK_NOK.order.domain.entity.CustomerSessionEntity;
+// import com.NOK_NOK.order.repository.CustomerSessionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -38,7 +38,7 @@ public class AdService {
     private final AdContentRepository adContentRepository;
     private final AdTargetRuleRepository adTargetRuleRepository;
     private final AdDisplayLogRepository adDisplayLogRepository;
-    private final CustomerSessionRepository customerSessionRepository;
+    // private final CustomerSessionRepository customerSessionRepository;
 
     /**
      * 전체 활성화 광고 조회
@@ -155,20 +155,20 @@ public class AdService {
     @Transactional
     public AdResponseDto.DisplayLogSaved saveDisplayLog(AdRequestDto.SaveDisplayLog request) {
         log.info("[광고 로그 저장] 시작 - sessionId: {}, adId: {}, duration: {}ms",
-                request.getSessionId(), request.getAdId(), request.getDurationMs());
+                /*request.getSessionId(),*/ request.getAdId(), request.getDurationMs());
 
         // 1. 유효성 검증
-        if (request.getSessionId() == null || request.getAdId() == null) {
-            throw new InvalidDisplayLogRequestException("sessionId와 adId는 필수입니다.");
+        if (/*request.getSessionId() == null ||*/ request.getAdId() == null) {
+            throw new InvalidDisplayLogRequestException(/*"sessionId와 */"adId는 필수입니다.");
         }
 
         if (request.getDisplayedAt() == null) {
             throw new InvalidDisplayLogRequestException("displayedAt은 필수입니다.");
         }
 
-        // 2. 세션 조회
-        CustomerSessionEntity session = customerSessionRepository.findById(request.getSessionId())
-                .orElseThrow(() -> new SessionNotFoundException(request.getSessionId()));
+        // // 2. 세션 조회
+        // CustomerSessionEntity session = customerSessionRepository.findById(request.getSessionId())
+        //         .orElseThrow(() -> new SessionNotFoundException(request.getSessionId()));
 
         // 3. 광고 조회
         AdContentEntity adContent = adContentRepository.findById(request.getAdId())
@@ -176,7 +176,7 @@ public class AdService {
 
         // 4. 로그 엔티티 생성
         AdDisplayLogEntity displayLog = AdDisplayLogEntity.builder()
-                .session(session)
+                // .session(session)
                 .adContent(adContent)
                 .displayedAt(request.getDisplayedAt())
                 .durationMs(request.getDurationMs())
@@ -189,7 +189,7 @@ public class AdService {
 
         return AdResponseDto.DisplayLogSaved.builder()
                 .displayId(savedLog.getDisplayId())
-                .sessionId(savedLog.getSession().getSessionId())
+                // .sessionId(savedLog.getSession().getSessionId())
                 .adId(savedLog.getAdContent().getAdId())
                 .adTitle(savedLog.getAdContent().getTitle())
                 .durationMs(savedLog.getDurationMs())

--- a/src/main/java/com/NOK_NOK/abs/service/AdService.java
+++ b/src/main/java/com/NOK_NOK/abs/service/AdService.java
@@ -1,0 +1,207 @@
+package com.NOK_NOK.abs.service;
+
+import com.NOK_NOK.abs.domain.dto.AdRequestDto;
+import com.NOK_NOK.abs.domain.dto.AdResponseDto;
+import com.NOK_NOK.abs.domain.entity.AdContentEntity;
+import com.NOK_NOK.abs.domain.entity.AdDisplayLogEntity;
+import com.NOK_NOK.abs.domain.entity.AdTargetRuleEntity;
+import com.NOK_NOK.abs.exceptions.AdExceptions.*;
+import com.NOK_NOK.abs.repository.AdContentRepository;
+import com.NOK_NOK.abs.repository.AdDisplayLogRepository;
+import com.NOK_NOK.abs.repository.AdTargetRuleRepository;
+import com.NOK_NOK.order.domain.entity.CustomerSessionEntity;
+import com.NOK_NOK.order.repository.CustomerSessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 광고 서비스
+ * 
+ * 기능:
+ * 1. 전체 광고 조회 (메인 화면용)
+ * 2. 결제 후 맞춤형 광고 조회
+ * 3. 광고 표시 로그 저장
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdService {
+
+    private final AdContentRepository adContentRepository;
+    private final AdTargetRuleRepository adTargetRuleRepository;
+    private final AdDisplayLogRepository adDisplayLogRepository;
+    private final CustomerSessionRepository customerSessionRepository;
+
+    /**
+     * 전체 활성화 광고 조회
+     * 
+     * API: GET /api/ads
+     * 
+     * 메인 화면에서 모든 광고를 React로 전달
+     * React에서 순서대로 표시 후 각 광고가 끝나면 로그 저장 API 호출
+     * 
+     * @return 활성화된 광고 목록
+     */
+    @Transactional(readOnly = true)
+    public AdResponseDto.AdList getAllActiveAds() {
+        log.info("[광고 조회] 전체 활성화 광고 조회 시작");
+
+        // 현재 날짜 기준 활성화된 광고만 조회
+        List<AdContentEntity> activeAds = adContentRepository.findAllActiveAds(LocalDate.now());
+
+        log.info("[광고 조회] 완료 - 광고 개수: {}", activeAds.size());
+
+        return AdResponseDto.AdList.from(activeAds);
+    }
+
+    /**
+     * 결제 후 맞춤형 광고 조회
+     * 
+     * API: GET /api/ads/payment?sessionId=1
+     * 
+     * 세션의 연령대, 성별 정보를 기반으로 타겟팅된 광고 제공
+     * 
+     * @param sessionId 세션 ID
+     * @return 맞춤형 광고 목록
+     */
+    @Transactional(readOnly = true)
+    public AdResponseDto.PaymentAdList getPaymentAds(Long sessionId) {
+        log.info("[맞춤 광고 조회] 시작 - sessionId: {}", sessionId);
+
+        // 1. 세션 조회
+        CustomerSessionEntity session = customerSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new SessionNotFoundException(sessionId));
+
+        String ageGroup = session.getAgeGroup();
+        String gender = session.getGender() != null ? session.getGender().name() : null;
+
+        log.info("[맞춤 광고 조회] 타겟 정보 - ageGroup: {}, gender: {}", ageGroup, gender);
+
+        // 2. 활성화된 모든 광고 조회
+        List<AdContentEntity> activeAds = adContentRepository.findAllActiveAds(LocalDate.now());
+
+        if (activeAds.isEmpty()) {
+            log.warn("[맞춤 광고 조회] 활성화된 광고 없음");
+            return AdResponseDto.PaymentAdList.builder()
+                    .ads(new ArrayList<>())
+                    .totalCount(0)
+                    .ageGroup(ageGroup)
+                    .gender(gender)
+                    .message("현재 표시할 광고가 없습니다.")
+                    .build();
+        }
+
+        // 3. 광고 ID 목록 추출
+        List<Long> adIds = activeAds.stream()
+                .map(AdContentEntity::getAdId)
+                .collect(Collectors.toList());
+
+        // 4. 타겟 규칙 일괄 조회
+        List<AdTargetRuleEntity> targetRules = adTargetRuleRepository.findByAdIdIn(adIds);
+
+        // 5. 광고별 타겟 규칙 그룹화
+        Map<Long, List<AdTargetRuleEntity>> rulesByAdId = targetRules.stream()
+                .collect(Collectors.groupingBy(rule -> rule.getAdContent().getAdId()));
+
+        // 6. 타겟팅 필터링
+        List<AdContentEntity> targetedAds = new ArrayList<>();
+
+        for (AdContentEntity ad : activeAds) {
+            List<AdTargetRuleEntity> rules = rulesByAdId.get(ad.getAdId());
+
+            // 타겟 규칙이 없으면 모든 사용자에게 표시
+            if (rules == null || rules.isEmpty()) {
+                targetedAds.add(ad);
+                continue;
+            }
+
+            // 하나 이상의 규칙과 매칭되면 표시
+            boolean matches = rules.stream()
+                    .anyMatch(rule -> rule.matches(ageGroup, gender));
+
+            if (matches) {
+                targetedAds.add(ad);
+            }
+        }
+
+        log.info("[맞춤 광고 조회] 완료 - 전체: {}, 타겟팅: {}", activeAds.size(), targetedAds.size());
+
+        // 7. DTO 변환
+        List<AdResponseDto.AdDetail> adDetails = targetedAds.stream()
+                .map(AdResponseDto.AdDetail::from)
+                .collect(Collectors.toList());
+
+        return AdResponseDto.PaymentAdList.builder()
+                .ads(adDetails)
+                .totalCount(adDetails.size())
+                .ageGroup(ageGroup)
+                .gender(gender)
+                .message(adDetails.isEmpty() ? 
+                        "해당 조건에 맞는 광고가 없습니다." : 
+                        "맞춤 광고를 제공합니다.")
+                .build();
+    }
+
+    /**
+     * 광고 표시 로그 저장
+     * 
+     * API: POST /api/ads/display-log
+     * 
+     * React에서 광고가 끝나면 호출하여 로그 저장
+     * 
+     * @param request 광고 로그 요청
+     * @return 저장 결과
+     */
+    @Transactional
+    public AdResponseDto.DisplayLogSaved saveDisplayLog(AdRequestDto.SaveDisplayLog request) {
+        log.info("[광고 로그 저장] 시작 - sessionId: {}, adId: {}, duration: {}ms",
+                request.getSessionId(), request.getAdId(), request.getDurationMs());
+
+        // 1. 유효성 검증
+        if (request.getSessionId() == null || request.getAdId() == null) {
+            throw new InvalidDisplayLogRequestException("sessionId와 adId는 필수입니다.");
+        }
+
+        if (request.getDisplayedAt() == null) {
+            throw new InvalidDisplayLogRequestException("displayedAt은 필수입니다.");
+        }
+
+        // 2. 세션 조회
+        CustomerSessionEntity session = customerSessionRepository.findById(request.getSessionId())
+                .orElseThrow(() -> new SessionNotFoundException(request.getSessionId()));
+
+        // 3. 광고 조회
+        AdContentEntity adContent = adContentRepository.findById(request.getAdId())
+                .orElseThrow(() -> new AdNotFoundException(request.getAdId()));
+
+        // 4. 로그 엔티티 생성
+        AdDisplayLogEntity displayLog = AdDisplayLogEntity.builder()
+                .session(session)
+                .adContent(adContent)
+                .displayedAt(request.getDisplayedAt())
+                .durationMs(request.getDurationMs())
+                .build();
+
+        // 5. 로그 저장
+        AdDisplayLogEntity savedLog = adDisplayLogRepository.save(displayLog);
+
+        log.info("[광고 로그 저장] 완료 - displayId: {}", savedLog.getDisplayId());
+
+        return AdResponseDto.DisplayLogSaved.builder()
+                .displayId(savedLog.getDisplayId())
+                .sessionId(savedLog.getSession().getSessionId())
+                .adId(savedLog.getAdContent().getAdId())
+                .adTitle(savedLog.getAdContent().getTitle())
+                .durationMs(savedLog.getDurationMs())
+                .message("광고 표시 로그가 저장되었습니다.")
+                .build();
+    }
+}


### PR DESCRIPTION
## 광고 데이터 제공 API 및 광고 로그 저장 API

**API:** `POST /api/ads/display-log`
`GET /api/ads`
`GET /api/ads/payment`

### 구현 내용
* 첫 화면에서 필요한 전체 광고 조회
* 결제 후 연령과 성별에 맞는 맞춤형 광고 조회
* 보여준 광고에 대한 정보 front에서 받아와 로그 저장

### 파일
* Entity 3개 (AdContentEntity, AdDisplayLogEntity, AdTargetRuleEntity)
* DTO 2개 (AdRequestDto, AdResponseDto)
* , Repository 3개 (AdContentRepository, AdDisplayLogRepository, AdTargetRuleRepository)
* Service 1개 (AdService)
* Controller 1개 (AdController)

### 테스트
- [x] Swagger UI 완료 ✅